### PR TITLE
feat!: php-fpm runtimes should now work as intended & corrected naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ After installling `pipx`, you can install `markitdown` with:
 pipx install markitdown
 ```
 
+Now, set the path to the `markitdown` executable in your `.env` file. You can retrieve the path with:
+```bash
+which markitdown
+```
+
+```bash
+MARKITDOWN_EXECUTABLE=/path/to/markitdown
+```
+
+Also, when running the script anywhere but the console, you need to set the PATH, as php-fpm does not have
+access to the PATH variable. You can do this by adding the following to your `.env` file:
+
+```bash
+echo $PATH
+```
+
+```bash
+MARKITDOWN_SYSTEM_PATH=<your path>
+```
+
 ### Publishing things
 
 You can publish the config file with:

--- a/config/markitdown.php
+++ b/config/markitdown.php
@@ -14,4 +14,13 @@ return [
      * the binary will be searched in the PATH.
      */
     'executable' => env('MARKITDOWN_EXECUTABLE', 'markitdown'),
+
+    /*
+     * This is needed when you want to run markitdown in php-fpm. One dependency
+     * of markitdown requires PATH to be set. If you are running in a console,
+     * this is not needed.
+     */
+    'system' => [
+        'path' => env('MARKITDOWN_SYSTEM_PATH', ''),
+    ],
 ];

--- a/tests/MarkitdownTest.php
+++ b/tests/MarkitdownTest.php
@@ -18,7 +18,7 @@ it('can convert excel', function (): void {
 });
 
 it('can convert from string', function (): void {
-    $conv = Markitdown::convertString(file_get_contents(__DIR__.'/Stubs/Take Notes.docx'));
+    $conv = Markitdown::convertFile(file_get_contents(__DIR__.'/Stubs/Take Notes.docx'), '.docx');
 
     expect($conv)->toMatchSnapshot();
 });


### PR DESCRIPTION
* fixes PATH issue in php-fpm runtime
* renames convertString to convertFile and adds `extension` parameter
* renames convert `filename` parameter to `filePath` as it is more appropriate