### PR TITLE
allow laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
-        "kauffinger/pyman": "^0.0.3",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
+        "kauffinger/pyman": "^0.0.3|^0.1.0",
         "spatie/laravel-package-tools": "^1.16",
         "spatie/temporary-directory": "^2.2"
     },
@@ -27,7 +27,7 @@
         "larastan/larastan": "^3",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.9.0",
+        "orchestra/testbench": "^10.9.0||^11.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",


### PR DESCRIPTION
## Summary
- Add `^13.0` to `illuminate/contracts` constraint
- Bump `kauffinger/pyman` to support Laravel 13 (`^0.1.0`)
- Allow `orchestra/testbench` ^11.0 for future Laravel 13 dev testing

Fixes #32

## Test plan
- [x] Verified package installs in a Laravel 13 app via Composer
- [x] Verified package still installs on Laravel 12
- [x] PHPStan passes locally
- [ ] CI passes on this PR